### PR TITLE
Make extractor faster

### DIFF
--- a/l10n/_commands/_extract.py
+++ b/l10n/_commands/_extract.py
@@ -30,8 +30,16 @@ class Extract(Command):
             help='language to generate a PO file for',
         )
         parser.add_argument(
+            '--wrap', default=90, type=int,
+            help='wrap msgstr longer than that many characters',
+        )
+        parser.add_argument(
             '--echo', action='store_true',
             help='set msgstr to the same value as msgid',
+        )
+        parser.add_argument(
+            '--allow-duplicates', action='store_true',
+            help='do not check the file for duplicates',
         )
         now = datetime.now(timezone.utc).astimezone()
         parser.add_argument(
@@ -57,10 +65,17 @@ class Extract(Command):
                 self.print(lang)
                 file_path = project.po_root / f'{lang}.po'
 
-                template_file = polib.POFile()
+                template_file = polib.POFile(
+                    wrapwidth=self.args.wrap,
+                    check_for_duplicates=not self.args.allow_duplicates,
+                )
                 template_file.extend(entries)
                 if file_path.exists():
-                    target_file = polib.pofile(str(file_path))
+                    target_file = polib.pofile(
+                        str(file_path),
+                        wrapwidth=self.args.wrap,
+                        check_for_duplicates=not self.args.allow_duplicates,
+                    )
                     target_file.merge(template_file)
                 else:
                     target_file = template_file

--- a/l10n/_extractor.py
+++ b/l10n/_extractor.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from textwrap import dedent
 from typing import Iterator, NamedTuple
 
 from mypy import types
@@ -13,6 +14,14 @@ from mypy.types import LiteralValue
 
 
 PREFIX = '__L10N__:'
+CONFIG = f"""
+    [mypy]
+    plugins = {__name__}
+    follow_imports = skip
+
+    [mypy-l10n.*]
+    follow_imports = normal
+"""
 
 
 class Message(NamedTuple):
@@ -31,7 +40,7 @@ class Message(NamedTuple):
 
 
 def extract_messages(project_path: Path) -> Iterator[Message]:
-    config = f'[mypy]\nplugins = {__name__}'
+    config = dedent(CONFIG)
     with NamedTemporaryFile() as tmp_file:
         tmp_file.write(config.encode())
         tmp_file.flush()


### PR DESCRIPTION
1. Extract messages faster by telling mypy to not follow any imports except l10n.
2. Add `--wrap` and `--allow-duplicates` CLI flags.